### PR TITLE
Use regime thresholds for trade gating

### DIFF
--- a/regime_thresholds.json
+++ b/regime_thresholds.json
@@ -1,0 +1,9 @@
+{
+  "super_bull": {"buy": 0.70, "sell": 0.30, "quality": 0.50},
+  "strong_bull": {"buy": 0.65, "sell": 0.35, "quality": 0.50},
+  "bull": {"buy": 0.60, "sell": 0.40, "quality": 0.40},
+  "mild_bull": {"buy": 0.55, "sell": 0.45, "quality": 0.30},
+  "neutral": {"buy": 0.60, "sell": 0.40, "quality": 0.40},
+  "volatile": {"buy": 0.60, "sell": 0.40, "quality": 0.50},
+  "bear": {"buy": 0.55, "sell": 0.45, "quality": 0.50}
+}


### PR DESCRIPTION
## Summary
- load regime-specific buy/sell/quality thresholds from `regime_thresholds.json`
- derive trade direction only when calibrated probability clears regime cutoffs and quality gate
- log both probability and quality score for executed trades

## Testing
- `python -m py_compile final_production_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a319b8c6488320b2d056968231c378