### PR TITLE
Use regime-based probability thresholds in live bot

### DIFF
--- a/artifacts/models/best/regime_thresholds.json
+++ b/artifacts/models/best/regime_thresholds.json
@@ -1,0 +1,7 @@
+{
+  "strong_bull": {"buy": 0.4, "sell": 0.3, "quality": 0.5},
+  "bull": {"buy": 0.5, "sell": 0.4, "quality": 0.55},
+  "neutral": {"buy": 0.6, "sell": 0.5, "quality": 0.6},
+  "bear": {"buy": 0.7, "sell": 0.4, "quality": 0.55},
+  "volatile": {"buy": 0.65, "sell": 0.45, "quality": 0.6}
+}


### PR DESCRIPTION
## Summary
- load `regime_thresholds.json` and detect a simple market regime using QQQ and VIX data
- apply regime-specific buy/sell probability thresholds with optional quality gate
- log and track trade probabilities instead of fixed confidence

## Testing
- `python -m py_compile alpaca_live_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a319b8c1248320be5ef7c109bbfb19