### PR TITLE
refactor: defer directory creation

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -23,6 +23,7 @@ from models.model_trainer import ModelTrainer
 from evaluation.backtester import Backtester
 from trading.paper_trader import PaperTrader
 from utils.logger import setup_logging
+from utils.config import ensure_dirs
 
 logger = logging.getLogger(__name__)
 
@@ -202,9 +203,10 @@ def main():
         parser.print_help()
         return
     
-    # Setup logging
+    # Setup logging and ensure required directories exist
     setup_logging()
-    
+    ensure_dirs()
+
     # Initialize manager
     manager = TradingSystemManager()
     

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -33,7 +33,10 @@ GAT_HIDDEN = 64
 GAT_OUT = 32
 DROPOUT = 0.3
 
-# ensure dirs
-os.makedirs(CHECKPOINT_DIR, exist_ok=True)
-os.makedirs(DATA_DIR, exist_ok=True)
-os.makedirs(LOG_DIR, exist_ok=True)
+
+def ensure_dirs() -> None:
+    """Create required directories for training and logging."""
+    os.makedirs(CHECKPOINT_DIR, exist_ok=True)
+    os.makedirs(DATA_DIR, exist_ok=True)
+    os.makedirs(LOG_DIR, exist_ok=True)
+


### PR DESCRIPTION
## Summary
- add `ensure_dirs` helper in `utils.config` to create data/checkpoint/log folders on demand
- call `ensure_dirs()` from `manager.py` instead of during module import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3257487c88320b35ad025aad43897