### PR TITLE
Remove unused imports in Sharpe loss module

### DIFF
--- a/src/training/sharpe_loss.py
+++ b/src/training/sharpe_loss.py
@@ -6,9 +6,7 @@ Risk-adjusted loss functions for portfolio optimization
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-import numpy as np
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 import logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Drop unused `torch.nn.functional` and `numpy` imports from `sharpe_loss.py`
- Remove unused `Tuple` type from typing imports

## Testing
- `python - <<'PY'` (AST-based check of unused imports)
- `python -m pyflakes src/training/sharpe_loss.py` *(fails: No module named pyflakes; attempted install blocked by proxy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a32579f28c8320aca3d5665f83b281