### PR TITLE
Use logger in super ensemble and handle zero accuracy

### DIFF
--- a/tests/test_super_ensemble_zero_sum.py
+++ b/tests/test_super_ensemble_zero_sum.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.models.super_ensemble import SuperEnsemble, ModelInfo
+
+def test_zero_sum_accuracy_weights():
+    # Create instance without invoking __init__
+    ensemble = SuperEnsemble.__new__(SuperEnsemble)
+    ensemble.model_info = {
+        'model_a': ModelInfo('model_a', 'dummy', {}, '', 0.0, 1.0),
+        'model_b': ModelInfo('model_b', 'dummy', {}, '', 0.0, 2.0),
+    }
+    SuperEnsemble.calculate_weights(ensemble)
+    weights = np.array([info.weight for info in ensemble.model_info.values()])
+    expected_loss_weights = np.array([1.0, 0.5])
+    expected_loss_weights = expected_loss_weights / expected_loss_weights.sum()
+    expected = 0.7 * np.array([0.5, 0.5]) + 0.3 * expected_loss_weights
+    assert np.allclose(weights, expected)


### PR DESCRIPTION
## Summary
- replace print statements in `SuperEnsemble` with `logging` calls
- guard against zero accuracy sums when computing weights and default to uniform weights
- add unit test for zero-sum accuracy weighting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3257d21008320ab16e8257113a500