### PR TITLE
Add paper trading agent and monitoring metrics integration

### DIFF
--- a/agents/monitoring_reporting_agent.py
+++ b/agents/monitoring_reporting_agent.py
@@ -38,6 +38,31 @@ class MonitoringReportingAgent:
         logger.info(f"   Daily Reports: {self.reporting_config.get('daily_reports', True)}")
         logger.info(f"   Performance Attribution: {self.reporting_config.get('performance_attribution', True)}")
         logger.info(f"   Risk Analytics: {self.reporting_config.get('risk_analytics', True)}")
+
+    def capture_trading_metrics(self, slippage_bps: float, exposure: Dict[str, float], drawdown: float) -> None:
+        """Capture real-time trading metrics"""
+
+        metrics = {
+            'timestamp': datetime.now().isoformat(),
+            'slippage_bps': slippage_bps,
+            'gross_exposure': exposure.get('gross', 0.0),
+            'net_exposure': exposure.get('net', 0.0),
+            'drawdown': drawdown,
+        }
+
+        metrics_dir = self.artifacts_dir / 'metrics'
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        metrics_file = metrics_dir / 'paper_trading_metrics.json'
+
+        existing = []
+        if metrics_file.exists():
+            try:
+                existing = json.loads(metrics_file.read_text())
+            except Exception:
+                existing = []
+        existing.append(metrics)
+        metrics_file.write_text(json.dumps(existing, indent=2))
+        logger.info(f"📊 Captured trading metrics: {metrics}")
         
     def generate_daily_report(self, date: Optional[str] = None) -> Dict[str, Any]:
         """

--- a/agents/paper_trading_agent.py
+++ b/agents/paper_trading_agent.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+PAPER TRADING AGENT - wraps src.trading.paper_trader.PaperTrader
+Exposes methods to start/stop trading and report P&L
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any
+
+from src.trading.paper_trader import PaperTrader
+from agents.monitoring_reporting_agent import MonitoringReportingAgent
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+class PaperTradingAgent:
+    """Agent to manage paper trading using PaperTrader"""
+
+    def __init__(self, trading_config: Dict[str, Any]):
+        logger.info("📝 PAPER TRADING AGENT INIT")
+
+        self.config = trading_config
+        paper_cfg = trading_config.get('paper_trading', {})
+
+        # Validation window (default 6 months)
+        self.validation_window_months = paper_cfg.get('validation_window_months', 6)
+        logger.info(f"   Validation window: {self.validation_window_months} months")
+
+        # Alpaca credentials
+        alpaca_cfg = paper_cfg.get('alpaca', {})
+        api_key = alpaca_cfg.get('api_key')
+        secret_key = alpaca_cfg.get('secret_key')
+        base_url = alpaca_cfg.get('base_url')
+
+        # Initialize PaperTrader
+        model_dir = paper_cfg.get('model_dir', 'artifacts/models/best')
+        self.trader = PaperTrader(
+            model_dir=model_dir,
+            max_gross=paper_cfg.get('max_gross', 0.6),
+            max_per_name=paper_cfg.get('max_per_name', 0.08),
+            api_key=api_key,
+            secret_key=secret_key,
+            base_url=base_url,
+        )
+
+        # Monitoring/reporting
+        self.monitor = MonitoringReportingAgent(trading_config)
+        self.peak_portfolio_value = self.trader.portfolio_value
+
+    def start_trading(self) -> None:
+        """Begin paper trading"""
+        logger.info("🚀 Starting paper trading")
+        self.trader.start_trading()
+
+    def stop_trading(self) -> None:
+        """Stop paper trading"""
+        logger.info("🛑 Stopping paper trading")
+        self.trader.is_trading = False
+        self.trader._cleanup()
+
+    def report_pnl(self) -> Dict[str, Any]:
+        """Report current P&L and capture monitoring metrics"""
+        self.trader._update_portfolio_info()
+
+        # Calculate exposures
+        exposure = self._calculate_exposure()
+
+        # Update drawdown
+        drawdown = self._calculate_drawdown()
+
+        # Slippage placeholder from config
+        slippage_bps = self.config.get('transaction_costs', {}).get('spread_slippage_bps', 0)
+
+        # Capture metrics via monitoring agent
+        self.monitor.capture_trading_metrics(slippage_bps, exposure, drawdown)
+
+        pnl_report = {
+            'timestamp': datetime.utcnow().isoformat(),
+            'portfolio_value': self.trader.portfolio_value,
+            'gross_exposure': exposure['gross'],
+            'net_exposure': exposure['net'],
+            'drawdown': drawdown,
+            'slippage_bps': slippage_bps,
+        }
+        logger.info(f"📊 P&L Report: {pnl_report}")
+        return pnl_report
+
+    def _calculate_exposure(self) -> Dict[str, float]:
+        total = 0.0
+        net = 0.0
+        if self.trader.positions:
+            for pos in self.trader.positions.values():
+                mv = float(getattr(pos, 'market_value', 0))
+                total += abs(mv)
+                net += mv
+        if self.trader.portfolio_value:
+            gross = total / self.trader.portfolio_value
+            net_exp = net / self.trader.portfolio_value
+        else:
+            gross = 0.0
+            net_exp = 0.0
+        return {'gross': gross, 'net': net_exp}
+
+    def _calculate_drawdown(self) -> float:
+        pv = self.trader.portfolio_value
+        if pv > self.peak_portfolio_value:
+            self.peak_portfolio_value = pv
+        if self.peak_portfolio_value == 0:
+            return 0.0
+        return (pv - self.peak_portfolio_value) / self.peak_portfolio_value
+
+
+def main():
+    """Manual test for the paper trading agent"""
+    import json
+    config_path = Path(__file__).parent.parent / 'config' / 'trading_config.json'
+    with open(config_path, 'r') as f:
+        cfg = json.load(f)
+    agent = PaperTradingAgent(cfg)
+    agent.report_pnl()
+
+
+if __name__ == "__main__":
+    main()

--- a/config/trading_config.json
+++ b/config/trading_config.json
@@ -62,6 +62,12 @@
     "duration_weeks": 10,
     "required_positive_ic": true,
     "cost_tolerance": 0.2,
-    "risk_limits_enforced": true
+    "risk_limits_enforced": true,
+    "validation_window_months": 6,
+    "alpaca": {
+      "api_key": "YOUR_ALPACA_API_KEY",
+      "secret_key": "YOUR_ALPACA_SECRET_KEY",
+      "base_url": "https://paper-api.alpaca.markets"
+    }
   }
 }

--- a/manager.py
+++ b/manager.py
@@ -181,11 +181,12 @@ class OrchestatorAgent:
         logger.info("📝 Starting Paper Trade...")
         
         try:
-            from agents.portfolio_execution_agent import PortfolioExecutionAgent
-            agent = PortfolioExecutionAgent(self.trading_config)
-            return agent.start_paper_trading()
+            from agents.paper_trading_agent import PaperTradingAgent
+            agent = PaperTradingAgent(self.trading_config)
+            agent.start_trading()
+            return True
         except ImportError:
-            logger.error("Paper trading not implemented yet")
+            logger.error("Paper trading agent not implemented yet")
             return False
     
     def _run_reporting_agent(self) -> bool:


### PR DESCRIPTION
## Summary
- Add `PaperTradingAgent` wrapping `PaperTrader` with start/stop/pnl reporting
- Capture slippage, exposure, and drawdown metrics via `MonitoringReportingAgent`
- Accept Alpaca credentials and validation window in trading config
- Wire orchestrator to use the new agent for paper trading

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6bfe403488320a30d1513275bb6dc