### PR TITLE
feat: fetch nasdaq listings and borrow data

### DIFF
--- a/agents/universe_data_agent.py
+++ b/agents/universe_data_agent.py
@@ -14,6 +14,8 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Tuple, Optional
 from scipy import stats
 import warnings
+import requests
+import os
 warnings.filterwarnings('ignore')
 
 # Setup logging
@@ -101,12 +103,11 @@ class UniverseDataAgent:
         try:
             # Get full NASDAQ listing
             nasdaq_symbols = self._fetch_nasdaq_universe()
-            
+
             if not nasdaq_symbols:
-                logger.warning("Failed to fetch NASDAQ universe, using fallback list")
-                # Fallback to comprehensive list
-                nasdaq_symbols = self._get_comprehensive_nasdaq_list()
-            
+                logger.error("Failed to fetch NASDAQ universe")
+                return None
+
             # Apply initial filters and create universe dataframe
             universe_data = []
             for symbol in nasdaq_symbols:
@@ -126,7 +127,23 @@ class UniverseDataAgent:
                 })
             
             universe_df = pd.DataFrame(universe_data)
-            
+
+            # Borrowability filter
+            if self.filters.get('borrowable_only', False):
+                filtered_symbols, borrow_stats = self._filter_borrowable(universe_df['Ticker'].tolist())
+                self.borrow_stats = borrow_stats
+                universe_df = universe_df[universe_df['Ticker'].isin(filtered_symbols)].copy()
+                universe_df['borrow_rate'] = universe_df['Ticker'].map(
+                    lambda s: borrow_stats['details'].get(s, {}).get('borrow_rate')
+                )
+            else:
+                self.borrow_stats = {
+                    'checked': len(universe_df),
+                    'shortable': len(universe_df),
+                    'dropped': 0,
+                    'details': {}
+                }
+
             logger.info(f"✅ Built universe: {len(universe_df)} NASDAQ stocks")
             return universe_df
             
@@ -135,96 +152,100 @@ class UniverseDataAgent:
             return None
     
     def _fetch_nasdaq_universe(self) -> List[str]:
-        """Fetch current NASDAQ universe"""
-        
+        """Fetch current NASDAQ universe from API or CSV"""
+
+        logger.info("📊 Fetching NASDAQ universe...")
+
+        url = "https://api.nasdaq.com/api/screener/stocks?tableonly=true&limit=0"
+        headers = {"User-Agent": "Mozilla/5.0"}
+
         try:
-            # Method 1: Use yfinance to get NASDAQ 100 + additional stocks
-            import yfinance as yf
-            
-            # Get NASDAQ 100 first
-            nasdaq_100_url = "https://en.wikipedia.org/wiki/NASDAQ-100"
-            try:
-                nasdaq_100_tables = pd.read_html(nasdaq_100_url)
-                nasdaq_100_df = nasdaq_100_tables[4]  # Usually the 5th table
-                nasdaq_100_symbols = nasdaq_100_df['Ticker'].str.replace('.', '-').tolist()
-            except:
-                nasdaq_100_symbols = []
-            
-            # Add comprehensive NASDAQ stock list
-            comprehensive_symbols = self._get_comprehensive_nasdaq_list()
-            
-            # Combine and deduplicate
-            all_symbols = list(set(nasdaq_100_symbols + comprehensive_symbols))
-            
-            logger.info(f"📊 Fetched {len(all_symbols)} NASDAQ symbols")
-            return all_symbols
-            
+            resp = requests.get(url, headers=headers, timeout=30)
+            resp.raise_for_status()
+            rows = resp.json().get("data", {}).get("table", {}).get("rows", [])
+            symbols = [
+                row["symbol"]
+                for row in rows
+                if row.get("exchange", "").upper() in {"NASDAQ", "NMS", "NAS"}
+            ]
+            logger.info(f"📊 Fetched {len(symbols)} NASDAQ symbols from API")
+            return symbols
         except Exception as e:
-            logger.warning(f"Failed to fetch NASDAQ universe: {e}")
+            logger.warning(f"Failed to fetch NASDAQ universe from API: {e}")
+            csv_path = self.base_dir / "data" / "nasdaq_listings.csv"
+            if csv_path.exists():
+                df = pd.read_csv(csv_path)
+                symbols = df["symbol"].tolist()
+                logger.info(f"📊 Fetched {len(symbols)} NASDAQ symbols from CSV")
+                return symbols
             return []
-    
-    def _get_comprehensive_nasdaq_list(self) -> List[str]:
-        """Get comprehensive NASDAQ stock list (active stocks only)"""
-        
-        # Comprehensive NASDAQ universe - ACTIVE stocks only (removed delisted/merged)
-        return [
-            # Technology - Large Cap
-            'AAPL', 'MSFT', 'GOOGL', 'GOOG', 'AMZN', 'TSLA', 'META', 'NVDA',
-            'NFLX', 'INTC', 'CSCO', 'ADBE', 'ORCL', 'CRM', 'AVGO', 'TXN',
-            'QCOM', 'AMAT', 'LRCX', 'KLAC', 'MCHP', 'ADI', 'INTU', 'ISRG',
-            'PYPL', 'SHOP', 'ROKU', 'ZM', 'DOCU', 'CRWD', 'OKTA',
-            
-            # Biotechnology & Healthcare
-            'AMGN', 'GILD', 'REGN', 'VRTX', 'BIIB', 'MRNA', 'ILMN', 'BMRN',
-            'IDXX', 'DXCM', 'TDOC', 'VEEV', 'ALGN', 'EXAS', 'PTON', 'PTCT', 
-            'SRPT', 'TECH', 'INCY', 'FOLD',
-            
-            # Consumer & Retail
-            'COST', 'SBUX', 'DLTR', 'ORLY', 'ROST', 'ULTA', 'LULU', 'NTES',
-            'BKNG', 'EXPE', 'EBAY', 'ETSY', 'CHWY', 'PINS', 'SNAP',
-            'MAR', 'WYNN', 'NCLH', 'CCL', 'TRIP', 'DASH', 'ABNB',
-            
-            # Communication & Media (active only)
-            'CMCSA', 'CHTR', 'SIRI', 'FOXA', 'FOX', 'TMUS',
-            'LBTYA', 'LBTYK', 'LBRDA', 'LBRDK', 'LILAK', 'LILA',
-            
-            # Industrial & Transportation
-            'HON', 'CSX', 'PCAR', 'FAST', 'CTAS', 'VRSK', 'PAYX', 'ADP',
-            'WDAY', 'TEAM', 'NOW', 'CDNS', 'SNPS', 'ANSS', 'PTC',
-            
-            # Financial Services (NASDAQ-listed)
-            'FISV', 'LCID', 'SOFI', 'HOOD', 'COIN', 'AFRM',
-            
-            # Energy & Materials
-            'ENPH', 'SEDG', 'PLUG', 'FCEL', 'BE', 'BLDP', 'FLNC',
-            
-            # REITs and Utilities
-            'EXR', 'CBRE', 'SBAC', 'CCI', 'AMT', 'DLR', 'EQIX', 'PSA',
-            
-            # Growth & Emerging
-            'DOCN', 'SNOW', 'PLTR', 'RBLX', 'U', 'DDOG', 'MDB', 'ZS', 
-            'NET', 'FSLY', 'TWLO',
-            
-            # Semiconductors (active only)
-            'AMD', 'MRVL', 'SWKS', 'QRVO', 'CRUS',
-            
-            # Additional High-Quality Names
-            'MNST', 'WBA', 'MDLZ', 'PEP', 'KHC', 'ATVI', 'EA', 'TTWO',
-            'NXPI', 'MELI', 'JD', 'PDD', 'BIDU', 'TME', 'BILI',
-            'IQ', 'VIPS', 'HUYA', 'DOYU', 'TIGR', 'FUTU', 'NIU',
-            
-            # Additional Tech
-            'PANW', 'FTNT', 'CHKP', 'CYBR', 'SPLK', 'DDOG', 'ESTC',
-            'COUP', 'BILL', 'SMAR', 'CFLT', 'GTLB', 'MNDY', 'FROG',
-            
-            # Additional Biotech
-            'SGEN', 'NBIX', 'ALNY', 'RARE', 'UTHR', 'ACAD', 'HALO',
-            'KRYS', 'MYGN', 'DVAX', 'VCEL', 'EDIT', 'CRSP', 'NTLA',
-            
-            # Additional Consumer
-            'POOL', 'FIVE', 'OLLI', 'WING', 'TXRH', 'SHAK', 'CMG',
-            'DNUT', 'BROS', 'CAVA', 'SWEETGREEN'  # Note: some may be newer IPOs
-        ]
+
+    def _filter_borrowable(self, symbols: List[str]) -> Tuple[List[str], Dict[str, Dict]]:
+        """Check borrow availability via Alpaca API and drop failing symbols"""
+
+        api_key = os.getenv("ALPACA_API_KEY_ID")
+        api_secret = os.getenv("ALPACA_API_SECRET_KEY")
+
+        if not api_key or not api_secret:
+            logger.warning("Alpaca API credentials not set; skipping borrow filter")
+            return symbols, {
+                'checked': len(symbols),
+                'shortable': len(symbols),
+                'dropped': 0,
+                'details': {}
+            }
+
+        borrow_details: Dict[str, Dict] = {}
+        keep = []
+
+        for symbol in symbols:
+            try:
+                asset_resp = requests.get(
+                    f"https://paper-api.alpaca.markets/v2/assets/{symbol}",
+                    headers={
+                        "APCA-API-KEY-ID": api_key,
+                        "APCA-API-SECRET-KEY": api_secret,
+                    },
+                    timeout=15,
+                )
+                asset_resp.raise_for_status()
+                asset = asset_resp.json()
+                shortable = asset.get("shortable", False)
+
+                borrow_rate = None
+                try:
+                    rate_resp = requests.get(
+                        f"https://api.alpaca.markets/v1beta1/borrow/rates/{symbol}",
+                        headers={
+                            "APCA-API-KEY-ID": api_key,
+                            "APCA-API-SECRET-KEY": api_secret,
+                        },
+                        timeout=15,
+                    )
+                    if rate_resp.status_code == 200:
+                        borrow_rate = rate_resp.json().get("rate")
+                except Exception:
+                    pass
+
+                borrow_details[symbol] = {
+                    'shortable': shortable,
+                    'borrow_rate': borrow_rate,
+                }
+
+                if shortable and borrow_rate is not None:
+                    keep.append(symbol)
+            except Exception as e:
+                logger.warning(f"Borrow check failed for {symbol}: {e}")
+
+        dropped = len(symbols) - len(keep)
+        stats = {
+            'checked': len(symbols),
+            'shortable': len(keep),
+            'dropped': dropped,
+            'details': borrow_details,
+        }
+        logger.info(f"🔒 Borrow filter: {len(keep)}/{len(symbols)} symbols shortable with rates")
+        return keep, stats
     
     def _download_price_data(self, symbols: List[str], lookback_days: int = 400) -> Optional[pd.DataFrame]:
         """Download OHLCV data with corporate actions adjustment"""
@@ -489,10 +510,20 @@ class UniverseDataAgent:
         # Save universe file
         universe_path = self.artifacts_dir / "universe" / f"nasdaq_tradeable_{date}.csv"
         universe_df.to_csv(universe_path, index=False)
-        
+
+        # Save borrow statistics for audit
+        borrow_path = self.artifacts_dir / "universe" / f"borrow_stats_{date}.json"
+        if hasattr(self, 'borrow_stats'):
+            with open(borrow_path, 'w') as f:
+                json.dump(self.borrow_stats, f, indent=2, default=str)
+        else:
+            borrow_path = None
+
         logger.info(f"✅ Artifacts saved:")
         logger.info(f"   Features: {features_path}")
         logger.info(f"   Universe: {universe_path}")
+        if borrow_path:
+            logger.info(f"   Borrow stats: {borrow_path}")
     
     def _generate_validation_report(self, df: pd.DataFrame, date: str) -> bool:
         """

--- a/data/nasdaq_listings.csv
+++ b/data/nasdaq_listings.csv
@@ -1,0 +1,6 @@
+symbol
+AAPL
+MSFT
+AMZN
+GOOGL
+TSLA


### PR DESCRIPTION
## Summary
- fetch live NASDAQ listings with API fallback to CSV
- screen universe for borrowable symbols using Alpaca and save audit stats
- persist borrow filter results alongside universe artifacts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6bfe8db94832092b062124e4f1a71