### PR TITLE
Refactor configuration constants into dataclass

### DIFF
--- a/src/evaluation/evaluate.py
+++ b/src/evaluation/evaluate.py
@@ -3,21 +3,39 @@ import numpy as np
 import matplotlib.pyplot as plt
 from dataset import UniverseDataset
 from model import HybridTransformerGAT
-from config import DEVICE
+from utils.config import trading_settings as settings
+
 
 def load_checkpoint(path, num_features):
-    ck = torch.load(path, map_location=DEVICE)
-    model = HybridTransformerGAT(num_features=num_features, d_model=64, nhead=4, dim_feedforward=128, nlayers=6, gat_hidden=64, gat_out=32, dropout=0.3, device=DEVICE)
-    model.load_state_dict(ck["model_state"]); model.to(DEVICE); model.eval()
+    ck = torch.load(path, map_location=settings.device)
+    model = HybridTransformerGAT(
+        num_features=num_features,
+        d_model=settings.d_model,
+        nhead=settings.nhead,
+        dim_feedforward=128,
+        nlayers=settings.transformer_layers,
+        gat_hidden=settings.gat_hidden,
+        gat_out=settings.gat_out,
+        dropout=settings.dropout,
+        device=settings.device,
+    )
+    model.load_state_dict(ck["model_state"])
+    model.to(settings.device)
+    model.eval()
     return model
+
 
 def predict_on_dataset(model, ds):
     loader = torch.utils.data.DataLoader(ds, batch_size=1, shuffle=False)
-    preds=[]; trues=[]
+    preds = []
+    trues = []
     for batch in loader:
-        batch = batch.to(DEVICE)
+        batch = batch.to(settings.device)
         with torch.no_grad():
             out = model(batch).cpu().numpy()
-        preds.append(out); trues.append(batch.y.cpu().numpy())
-    preds = np.concatenate(preds); trues = np.concatenate(trues)
+        preds.append(out)
+        trues.append(batch.y.cpu().numpy())
+    preds = np.concatenate(preds)
+    trues = np.concatenate(trues)
     return preds, trues
+

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -4,53 +4,107 @@ Configuration management for AI Trading Bot
 """
 
 import os
-from typing import Optional
-from dotenv import load_dotenv
+import json
 import logging
+from dataclasses import dataclass, asdict, replace
+from typing import List
+from dotenv import load_dotenv
 
 # Load environment variables
 load_dotenv()
 
-# Legacy config for backward compatibility
-START_DATE = "2020-01-01"
-END_DATE = "2024-12-31"
-TICKERS = ["AAPL","MSFT","GOOG","AMZN","NVDA","TSLA","META","AMD","INTC","QCOM"]
-NEWS_API_KEY = os.environ.get("NEWS_API_KEY", "YOUR_NEWSAPI_KEY_HERE")
+@dataclass
+class TradingSettings:
+    """Model and training settings with reasonable defaults."""
 
-# Universe & windows
-TOP_N = 30
-TIME_WINDOW = 30
-SEQ_LEN = 30
+    # Legacy config for backward compatibility
+    start_date: str = "2020-01-01"
+    end_date: str = "2024-12-31"
+    tickers: List[str] = ("AAPL,MSFT,GOOG,AMZN,NVDA,TSLA,META,AMD,INTC,QCOM".split(","))
+    news_api_key: str = os.environ.get("NEWS_API_KEY", "YOUR_NEWSAPI_KEY_HERE")
 
-# Training / runtime
-DEVICE = "cuda" if os.environ.get("CUDA_VISIBLE_DEVICES") else "cpu"
-BATCH_SIZE = 8
-EPOCHS = 60
-LR = 3e-4
-WEIGHT_DECAY = 1e-5
-GRAD_CLIP = 1.0
-PATIENCE = 8
-CHECKPOINT_DIR = "checkpoints"
-BEST_MODEL_PATH = f"{CHECKPOINT_DIR}/best_model.pth"
-DATA_DIR = "data"
-LOG_DIR = "runs"
+    # Universe & windows
+    top_n: int = 30
+    time_window: int = 30
+    seq_len: int = 30
 
-# Model hyperparams
-D_MODEL = 64
-NHEAD = 4
-TRANSFORMER_LAYERS = 6
-GAT_HIDDEN = 64
-GAT_OUT = 32
-DROPOUT = 0.3
+    # Training / runtime
+    device: str = "cuda" if os.environ.get("CUDA_VISIBLE_DEVICES") else "cpu"
+    batch_size: int = 8
+    epochs: int = 60
+    lr: float = 3e-4
+    weight_decay: float = 1e-5
+    grad_clip: float = 1.0
+    patience: int = 8
+    checkpoint_dir: str = "checkpoints"
+    best_model_path: str = "checkpoints/best_model.pth"
+    data_dir: str = "data"
+    log_dir: str = "runs"
 
-# ensure dirs
-os.makedirs(CHECKPOINT_DIR, exist_ok=True)
-os.makedirs(DATA_DIR, exist_ok=True)
-os.makedirs(LOG_DIR, exist_ok=True)
+    # Model hyperparams
+    d_model: int = 64
+    nhead: int = 4
+    transformer_layers: int = 6
+    gat_hidden: int = 64
+    gat_out: int = 32
+    dropout: float = 0.3
+
+    def to_dict(self) -> dict:
+        """Serialize settings to a dictionary."""
+        return asdict(self)
+
+    def to_json(self) -> str:
+        """Serialize settings to a JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_env(cls) -> "TradingSettings":
+        """Load settings with optional environment overrides."""
+        base = cls()
+        tickers = os.getenv("TICKERS", ",".join(base.tickers)).split(",")
+        return replace(
+            base,
+            start_date=os.getenv("START_DATE", base.start_date),
+            end_date=os.getenv("END_DATE", base.end_date),
+            tickers=[t.strip() for t in tickers if t.strip()],
+            news_api_key=os.getenv("NEWS_API_KEY", base.news_api_key),
+            top_n=int(os.getenv("TOP_N", base.top_n)),
+            time_window=int(os.getenv("TIME_WINDOW", base.time_window)),
+            seq_len=int(os.getenv("SEQ_LEN", base.seq_len)),
+            device=os.getenv("DEVICE", base.device),
+            batch_size=int(os.getenv("BATCH_SIZE", base.batch_size)),
+            epochs=int(os.getenv("EPOCHS", base.epochs)),
+            lr=float(os.getenv("LR", base.lr)),
+            weight_decay=float(os.getenv("WEIGHT_DECAY", base.weight_decay)),
+            grad_clip=float(os.getenv("GRAD_CLIP", base.grad_clip)),
+            patience=int(os.getenv("PATIENCE", base.patience)),
+            checkpoint_dir=os.getenv("CHECKPOINT_DIR", base.checkpoint_dir),
+            best_model_path=os.getenv("BEST_MODEL_PATH", base.best_model_path),
+            data_dir=os.getenv("DATA_DIR", base.data_dir),
+            log_dir=os.getenv("LOG_DIR", base.log_dir),
+            d_model=int(os.getenv("D_MODEL", base.d_model)),
+            nhead=int(os.getenv("NHEAD", base.nhead)),
+            transformer_layers=int(os.getenv("TRANSFORMER_LAYERS", base.transformer_layers)),
+            gat_hidden=int(os.getenv("GAT_HIDDEN", base.gat_hidden)),
+            gat_out=int(os.getenv("GAT_OUT", base.gat_out)),
+            dropout=float(os.getenv("DROPOUT", base.dropout)),
+        )
+
+
+# Instantiate settings and ensure directories
+trading_settings = TradingSettings.from_env()
+os.makedirs(trading_settings.checkpoint_dir, exist_ok=True)
+os.makedirs(trading_settings.data_dir, exist_ok=True)
+os.makedirs(trading_settings.log_dir, exist_ok=True)
+# Backward compatible alias
+settings = trading_settings
 
 class TradingConfig:
     """Centralized configuration management"""
-    
+
+    # Dataclass-based settings
+    settings: TradingSettings = trading_settings
+
     # Alpaca API
     ALPACA_API_KEY: str = os.getenv('ALPACA_API_KEY', '')
     ALPACA_SECRET_KEY: str = os.getenv('ALPACA_SECRET_KEY', '')
@@ -101,6 +155,11 @@ class TradingConfig:
         
         logging.info("✅ Configuration validated successfully")
         return True
+
+    @classmethod
+    def serialize_settings(cls) -> str:
+        """Return current dataclass settings as JSON."""
+        return cls.settings.to_json()
     
     @classmethod
     def get_base_url(cls) -> str:


### PR DESCRIPTION
## Summary
- Replace scattered training constants with a `TradingSettings` dataclass that loads environment overrides via `dataclasses.replace`
- Expose helper methods for serializing settings and integrate instance into `TradingConfig`
- Update evaluation utilities to consume the centralized settings object

## Testing
- `pytest` *(fails: command not found)*
- `python3 -m py_compile src/utils/config.py src/evaluation/evaluate.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6d607ebb48320a158e95b4db7df0b