### PR TITLE
chore: allow critical warnings in model agent

### DIFF
--- a/agents/production_model_agent.py
+++ b/agents/production_model_agent.py
@@ -15,7 +15,9 @@ from typing import Dict, List, Tuple, Optional
 from sklearn.preprocessing import StandardScaler
 from scipy.stats import spearmanr
 import warnings
-warnings.filterwarnings('ignore')
+
+# Only suppress non-critical warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- remove blanket warning suppression in the production model agent and only ignore `DeprecationWarning`

## Testing
- `pytest`
- `python - <<'PY'
import warnings
warnings.warn('Test UserWarning', UserWarning)
warnings.warn('Test FutureWarning', FutureWarning)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a6d6d33410832098ca4dc091292cc1