### PR TITLE
Use NYSE calendar for trading schedule

### DIFF
--- a/requirements_optimization.txt
+++ b/requirements_optimization.txt
@@ -91,6 +91,7 @@ pymc==5.15.0                     # Probabilistic modeling (optional)
 python-dateutil==2.9.0.post0     # Date utilities
 pytz==2024.1                     # Timezone handling
 holidays==0.49                   # Holiday calendars
+pandas-market-calendars==4.4.4    # Exchange trading calendars
 
 # === OPTIMIZATION UTILITIES ===
 hyperopt==0.2.7                  # Alternative hyperparameter optimization


### PR DESCRIPTION
## Summary
- integrate pandas_market_calendars with TradingScheduler for NYSE session awareness
- gate trading tasks to open market hours and normalize timestamps to America/New_York
- document dependency for exchange calendars

## Testing
- `python -m py_compile PRODUCTION/bots/trading_scheduler.py`
- `pip install pandas_market_calendars` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a861e2a9848320a38b02abd54f0b39