### PR TITLE
Add trading supervisor and orchestration documentation

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -1,0 +1,21 @@
+# Orchestration Options
+
+This repository relies on a simple cron-based schedule by default. For more
+coordinated retry and backfill support, evaluate modern orchestration tools.
+
+## Prefect
+- **Pros:** Python-native workflows, automatic retries, and built-in support for
+  backfills.
+- **Cons:** Requires an extra service (Prefect server or cloud) and additional
+  dependencies.
+
+## Airflow
+- **Pros:** Battle-tested scheduler with DAG-based backfill capabilities and rich
+  retry policies.
+- **Cons:** Heavier to deploy and maintain compared to Prefect. Best suited for
+  larger teams and complex pipelines.
+
+## Cron (Fallback)
+- Minimal dependency surface and already part of the deployment playbook.
+- Use as a fallback when Prefect or Airflow are unavailable or during simple
+  single-machine setups.

--- a/PRODUCTION_GUIDE.md
+++ b/PRODUCTION_GUIDE.md
@@ -172,3 +172,11 @@ python PRODUCTION/tools/fix_conformal_gate.py
 
 🏛️ **INSTITUTIONAL-GRADE AI TRADING SYSTEM**  
 Ready for production deployment and 6-month live validation period.
+
+## 🔄 Failover & Restart Procedures
+- Run the supervisor with `python trading_supervisor.py` to ensure a single instance of the trading system.
+- If the system stops unexpectedly:
+  1. Inspect `supervisor.lock` and `trading_system.lock` to confirm processes are not running.
+  2. Remove stale lock files and restart the supervisor.
+  3. Review logs under `PRODUCTION/logs/` for root-cause analysis.
+- Cron or future orchestration tools (Prefect/Airflow) can be used to re-launch the supervisor as needed.

--- a/trading_supervisor.py
+++ b/trading_supervisor.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Supervisor for the automated trading system.
+
+- References the exchange calendar when available to decide if today is a trading day.
+- Ensures only a single instance of the supervisor runs via a lock file.
+- Launches the main trading system script when appropriate.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+try:  # Optional dependency for real exchange calendars
+    import pandas as pd
+    import exchange_calendars as ec
+except Exception:  # Fallback if package not installed
+    ec = None  # type: ignore
+    pd = None  # type: ignore
+
+LOCK_FILE = Path("supervisor.lock")
+TRADING_SCRIPT = Path("run_automated_trading.py")
+EXCHANGE = "XNYS"  # New York Stock Exchange
+
+
+def is_trading_day(day: datetime | None = None) -> bool:
+    """Return True if *day* is a trading session for the target exchange.
+
+    Uses ``exchange_calendars`` when available, otherwise falls back to a
+    simple weekday check.
+    """
+    day = day or datetime.now()
+    if ec and pd:
+        cal = ec.get_calendar(EXCHANGE)
+        return cal.is_session(pd.Timestamp(day.date()))
+    return day.weekday() < 5  # Mon-Fri fallback
+
+
+def main() -> None:
+    if LOCK_FILE.exists():
+        print("❌ Supervisor already running")
+        return
+
+    LOCK_FILE.write_text(f"Started: {datetime.now()}\nPID: {os.getpid()}\n")
+    try:
+        if not is_trading_day():
+            print("📅 Not a trading day – exiting")
+            return
+
+        if not TRADING_SCRIPT.exists():
+            print(f"❌ Trading script {TRADING_SCRIPT} not found")
+            return
+
+        print("🚀 Launching automated trading system")
+        proc = subprocess.Popen([sys.executable, str(TRADING_SCRIPT)])
+        proc.wait()
+    finally:
+        try:
+            LOCK_FILE.unlink()
+        except FileNotFoundError:
+            pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `trading_supervisor.py` to coordinate the automated system, referencing exchange calendars when available and preventing multiple instances
- Document orchestration options comparing Prefect, Airflow, and cron fallback
- Document failover and restart procedures in `PRODUCTION_GUIDE.md`

## Testing
- `python -m py_compile trading_supervisor.py`
- `pytest` (no tests discovered)
- `pip install exchange_calendars` *(failed: 403 Client Error: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a861e7efa08320a277c665468cfb76