### PR TITLE
Add production runbooks and safe restart utility

### DIFF
--- a/PRODUCTION/docs/runbooks/missing_data.md
+++ b/PRODUCTION/docs/runbooks/missing_data.md
@@ -1,0 +1,23 @@
+# Missing Data Runbook
+
+## Symptoms
+- Data pipeline logs show missing or empty datasets.
+- Alerts for incomplete bars or missing fields.
+
+## Immediate Actions
+1. Verify connectivity to data providers.
+2. Re-run the daily pipeline:
+   ```bash
+   python pipelines/update_daily.py --update-training
+   ```
+3. If primary provider is down, switch to fallback sources in `data_providers/`.
+
+## Verification
+- Ensure `data/` directories contain fresh files.
+- Run a quick audit:
+   ```bash
+   python PRODUCTION/tools/institutional_audit_system.py
+   ```
+
+## Escalation
+- If data is still missing after two retries, escalate to the data provider and pause automated trading.

--- a/PRODUCTION/docs/runbooks/off_calendar_openings.md
+++ b/PRODUCTION/docs/runbooks/off_calendar_openings.md
@@ -1,0 +1,21 @@
+# Off-Calendar Openings Runbook
+
+## Symptoms
+- Market appears open on expected holiday or weekend.
+- Unexpected price data during closed sessions.
+
+## Immediate Actions
+1. Verify official exchange calendar and holiday schedules.
+2. Halt trading and prevent auto-restart:
+   ```bash
+   pkill -f run_automated_trading.py
+   touch trading_system.lock
+   ```
+3. Confirm with broker whether trading is valid.
+
+## Verification
+- Resume trading only when market hours are confirmed.
+- Remove the manual lock file before restart.
+
+## Escalation
+- If discrepancy persists, escalate to exchange or data provider and keep system offline.

--- a/PRODUCTION/docs/runbooks/partial_fills.md
+++ b/PRODUCTION/docs/runbooks/partial_fills.md
@@ -1,0 +1,20 @@
+# Partial Fills Runbook
+
+## Symptoms
+- Orders remain in `partially_filled` status.
+- Position sizes differ from intended allocation.
+
+## Immediate Actions
+1. Check open orders:
+   ```bash
+   python check_positions.py
+   ```
+2. Cancel remaining unfilled orders via broker dashboard or API.
+3. Decide whether to re-submit the residual quantity.
+
+## Verification
+- Confirm position sizes match targets.
+- Review logs for unexpected order activity.
+
+## Escalation
+- If partial fills persist across sessions, contact the broker for support.

--- a/PRODUCTION/docs/runbooks/rate_limit_errors.md
+++ b/PRODUCTION/docs/runbooks/rate_limit_errors.md
@@ -1,0 +1,17 @@
+# Rate-Limit Errors Runbook
+
+## Symptoms
+- API responses return HTTP 429.
+- Logs contain `rate limit` warnings.
+
+## Immediate Actions
+1. Pause requests for 60 seconds to respect cooldowns.
+2. Enable exponential backoff in affected scripts.
+3. Reduce batch sizes or request frequency.
+
+## Verification
+- Retry the previous operation and confirm success.
+- Monitor logs to ensure rate-limit errors cease.
+
+## Escalation
+- If limits continue to be hit, request higher quotas from the provider or stagger jobs.

--- a/PRODUCTION/docs/runbooks/safe_shutdown_resume.md
+++ b/PRODUCTION/docs/runbooks/safe_shutdown_resume.md
@@ -1,0 +1,16 @@
+# Safe Shutdown & Resume Runbook
+
+Use this procedure to gracefully stop and restart the automated trading system without duplicating jobs.
+
+## Command
+```bash
+python PRODUCTION/tools/safe_restart.py
+```
+This command sends a gentle interrupt, waits for the system to cleanly exit, and then relaunches it. The `trading_system.lock` file ensures exactly one instance is running.
+
+## Verification
+- Watch the console for `Trading system stopped` followed by `Trading system started`.
+- Confirm a single `trading_system.lock` file exists.
+
+## Escalation
+- If the system fails to stop or start within 30 seconds, inspect logs and manually kill the process before retrying.

--- a/PRODUCTION/tools/safe_restart.py
+++ b/PRODUCTION/tools/safe_restart.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Safe restart utility for the automated trading system.
+
+Sends a soft interrupt to the running system, waits for a clean shutdown,
+then relaunches it. Uses the `trading_system.lock` file to guarantee
+exactly-once semantics.
+"""
+
+from pathlib import Path
+import os
+import signal
+import subprocess
+import sys
+import time
+
+LOCK_FILE = Path("trading_system.lock")
+TARGET_SCRIPT = Path("run_automated_trading.py")
+
+def _read_pid() -> int | None:
+    if LOCK_FILE.exists():
+        with open(LOCK_FILE) as f:
+            for line in f:
+                if line.startswith("PID"):
+                    try:
+                        return int(line.split(":", 1)[1].strip())
+                    except ValueError:
+                        return None
+    return None
+
+def stop_system():
+    pid = _read_pid()
+    if pid:
+        print(f"Stopping trading system (PID {pid})...")
+        try:
+            os.kill(pid, signal.SIGINT)
+        except ProcessLookupError:
+            print("Process not found; removing stale lock.")
+            if LOCK_FILE.exists():
+                LOCK_FILE.unlink()
+            return
+        for _ in range(30):
+            if not LOCK_FILE.exists():
+                print("Trading system stopped.")
+                return
+            time.sleep(1)
+        print("Timeout waiting for shutdown; removing lock file.")
+        LOCK_FILE.unlink(missing_ok=True)
+    else:
+        print("No running trading system found.")
+
+def start_system():
+    if LOCK_FILE.exists():
+        print("Lock file present; aborting start to avoid duplicate run.")
+        return
+    print("Starting trading system...")
+    subprocess.Popen([sys.executable, str(TARGET_SCRIPT)])
+    for _ in range(30):
+        if LOCK_FILE.exists():
+            print("Trading system started.")
+            return
+        time.sleep(1)
+    print("Warning: trading system did not create lock file.")
+
+def main():
+    stop_system()
+    start_system()
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ NEWS_API_KEY=your_news_key              # News sentiment
 - **Risk**: Monitor exposure and loss limits
 - **Data**: Verify daily fetch success
 
+## 📘 Runbooks
+
+Operational playbooks for common scenarios are available in [PRODUCTION/docs/runbooks](PRODUCTION/docs/runbooks):
+
+- [Missing Data](PRODUCTION/docs/runbooks/missing_data.md)
+- [Partial Fills](PRODUCTION/docs/runbooks/partial_fills.md)
+- [Rate-Limit Errors](PRODUCTION/docs/runbooks/rate_limit_errors.md)
+- [Off-Calendar Openings](PRODUCTION/docs/runbooks/off_calendar_openings.md)
+- [Safe Shutdown & Resume](PRODUCTION/docs/runbooks/safe_shutdown_resume.md)
+
 ---
 
 ## 📊 Performance Validation


### PR DESCRIPTION
## Summary
- Add operational runbooks for missing data, partial fills, rate-limit errors, off-calendar openings, and safe restart
- Introduce `safe_restart.py` for one-command shutdown and restart with exactly-once semantics
- Link runbooks from README for easy access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a861e9128883208cf1721b85c50791